### PR TITLE
Add more logs + sync timeout 

### DIFF
--- a/crates/rpc-tester-cli/src/main.rs
+++ b/crates/rpc-tester-cli/src/main.rs
@@ -103,9 +103,8 @@ pub async fn wait_for_readiness<P: Provider<AnyNetwork>>(
             let range = tip2 - (block_size_range - 1)..=tip2;
             info!(?range, "testing block range");
             return Ok(range);
-        } else {
-            info!(?tip1, ?tip2, "rpc1 is behind rpc2, waiting for it to catch up");
         }
+        info!(?tip1, ?tip2, "rpc1 is behind rpc2, waiting for it to catch up");
 
         sleep();
     }

--- a/crates/rpc-tester-cli/src/main.rs
+++ b/crates/rpc-tester-cli/src/main.rs
@@ -4,7 +4,7 @@ use alloy_provider::{network::AnyNetwork, Provider, ProviderBuilder};
 use alloy_rpc_types::SyncStatus;
 use clap::Parser;
 use rpc_tester::RpcTester;
-use std::{ops::RangeInclusive, thread::sleep, time::Duration};
+use std::{ops::RangeInclusive, thread::sleep, time::Duration, time::Instant};
 use tracing::info;
 use url::Url;
 
@@ -35,6 +35,10 @@ pub struct CliArgs {
     /// Whether to query every transacion from a block or just the first.
     #[arg(long, value_name = "ALL_TXES", default_value = "false")]
     pub use_all_txes: bool,
+
+    /// Maximum time to wait for syncing in seconds
+    #[arg(long, value_name = "TIMEOUT", default_value = "300")]
+    pub timeout: u64,
 }
 
 #[tokio::main]
@@ -70,9 +74,18 @@ pub async fn wait_for_readiness<P: Provider<AnyNetwork>>(
     block_size_range: u64,
 ) -> eyre::Result<RangeInclusive<u64>> {
     let sleep = || sleep(Duration::from_secs(5));
+    let args = CliArgs::parse();
+    let start_time = Instant::now();
+    let timeout = Duration::from_secs(args.timeout);
 
     // Waits until it's done syncing
     while let SyncStatus::Info(sync_info) = rpc1.syncing().await? {
+        if start_time.elapsed() > timeout {
+            return Err(eyre::eyre!(
+                "Timeout waiting for rpc1 to sync after {} seconds",
+                args.timeout
+            ));
+        }
         info!(?sync_info, "rpc1 still syncing");
         sleep();
     }
@@ -86,6 +99,8 @@ pub async fn wait_for_readiness<P: Provider<AnyNetwork>>(
             let range = tip2 - (block_size_range - 1)..=tip2;
             info!(?range, "testing block range");
             return Ok(range);
+        } else {
+            info!(?tip1, ?tip2, "rpc1 is behind rpc2, waiting for it to catch up");
         }
 
         sleep();

--- a/crates/rpc-tester-cli/src/main.rs
+++ b/crates/rpc-tester-cli/src/main.rs
@@ -4,7 +4,11 @@ use alloy_provider::{network::AnyNetwork, Provider, ProviderBuilder};
 use alloy_rpc_types::SyncStatus;
 use clap::Parser;
 use rpc_tester::RpcTester;
-use std::{ops::RangeInclusive, thread::sleep, time::Duration, time::Instant};
+use std::{
+    ops::RangeInclusive,
+    thread::sleep,
+    time::{Duration, Instant},
+};
 use tracing::info;
 use url::Url;
 

--- a/crates/rpc-tester/src/report.rs
+++ b/crates/rpc-tester/src/report.rs
@@ -31,7 +31,8 @@ pub(crate) fn report(results_by_block: ReportResults) -> eyre::Result<()> {
                 }
                 Err(TestError::Rpc1Err(err) | TestError::Rpc2Err(err)) => {
                     passed_title = false;
-                    println!("\n{title} ❌\n{err}");
+                    println!("\n{title} ❌");
+                    println!("    {name}: ❌ {}", err);
                 }
             }
         }


### PR DESCRIPTION
**Add function name in results for better debugging**

before

```
Block Number 7936923 ❌
rpc1: ErrorResp(ErrorPayload { code: -32601, message: "Method not found", data: None })

Block Number 7936923 ❌
rpc1: ErrorResp(ErrorPayload { code: -32601, message: "Method not found", data: None })
```

after

```
Block Number 7936915 ❌
    getHeaderByNumber: ❌ rpc1: ErrorResp(ErrorPayload { code: -32601, message: "Method not found", data: None })

Block Number 7936915 ❌
    getHeaderByHash: ❌ rpc1: ErrorResp(ErrorPayload { code: -32601, message: "Method not found", data: None })
```

**Add timeout for checking sync**
ran into an issue when node wasn't synced and not catching up, so added log & ability to configure timeout, so it doesn't try catching up forever