### PR TITLE
Use correct function name 

### DIFF
--- a/crates/rpc-tester/src/tester.rs
+++ b/crates/rpc-tester/src/tester.rs
@@ -94,8 +94,8 @@ where
                 rpc!(self, get_uncle_count, BlockId::Hash(block_hash.into())),
                 rpc!(self, get_uncle_count, BlockId::Number(block_tag)),
                 rpc!(self, get_block_receipts, block_id),
-                rpc_raw!(self, getHeaderByNumber, AnyRpcHeader, (block_tag,)),
-                rpc_raw!(self, getHeaderByHash, AnyRpcHeader, (block_hash,)),
+                rpc_raw!(self, eth_getHeaderByNumber, AnyRpcHeader, (block_tag,)),
+                rpc_raw!(self, eth_getHeaderByHash, AnyRpcHeader, (block_hash,)),
                 rpc_raw!(self, reth_getBalanceChangesInBlock, BalanceChanges, (block_id,)),
                 rpc!(self, trace_block, block_id),
                 get_logs!(self, &Filter::new().select(block_number))


### PR DESCRIPTION
should be `eth_getHeaderByNumber` and `eth_getHeaderByHash` 

fixes errors in workflow https://github.com/ithacaxyz/infra-techops/actions/runs/13966909302/job/39099633414#step:7:53

```
--- RPC Method Test Results ---

Block Number 7941603 ❌
    getHeaderByNumber: ❌ rpc1: ErrorResp(ErrorPayload { code: -32601, message: "Method not found", data: None })
```

couple more errors to go 