### PR TITLE
chore: make errors more informative

### DIFF
--- a/crates/rpc-tester/src/lib.rs
+++ b/crates/rpc-tester/src/lib.rs
@@ -7,7 +7,7 @@ mod report;
 
 /// Equality rpc test error
 enum TestError {
-    Diff { rpc1: serde_json::Value, rpc2: serde_json::Value },
+    Diff { rpc1: serde_json::Value, rpc2: serde_json::Value, args: Option<String> },
     Rpc1Err(String),
     Rpc2Err(String),
 }
@@ -21,54 +21,61 @@ type MethodName = String;
 /// Provider macro that boxes all method future results.
 #[macro_export]
 macro_rules! rpc {
-    ($self:expr, $method:ident $(, $args:expr )* ) => {
+    ($self:expr, $method:ident $(, $args:expr )* ) => {{
+        let args_str = Some(format!("{}", [$(format!("{:?}", $args)),*].join(", ")));
         Box::pin($self.test_rpc_call(
             stringify!($method),
+            args_str,
             move |provider: &P| {
                 provider.$method( $( $args.clone(), )*)
             }
         )) as Pin<Box<dyn Future<Output = (MethodName, Result<(), TestError>)> + Send>>
-    };
+    }};
 }
 
 /// Provider macro to call methods that return `RpcWithBlock` and box the future results.
 #[macro_export]
 macro_rules! rpc_with_block {
-    ($self:expr, $method:ident $(, $args:expr )*; $blockid:expr) => {
+    ($self:expr, $method:ident $(, $args:expr )*; $blockid:expr) => {{
+        let args_str = Some(format!("{}, block_id: {:?}", [$(format!("{:?}", $args)),*].join(", "), $blockid));
         Box::pin($self.test_rpc_call(
             stringify!($method),
+            args_str,
             move |provider: &P| {
                 provider.$method( $( $args.clone(), )*).block_id($blockid).into_future()
             }
         )) as Pin<Box<dyn Future<Output = (MethodName, Result<(), TestError>)> + Send>>
-    };
+    }};
 }
 
 /// Macro to call the `get_logs` rpc method and box the future result.
 #[macro_export]
 macro_rules! get_logs {
-    ($self:expr, $arg:expr) => {
+    ($self:expr, $arg:expr) => {{
+        let args_str = Some(format!("{:?}", $arg));
         Box::pin(async move {
             let filter = $arg.clone();
             $self
-                .test_rpc_call(stringify!(get_logs), move |provider: &P| {
+                .test_rpc_call(stringify!(get_logs), args_str, move |provider: &P| {
                     let filter = filter.clone();
                     async move { provider.get_logs(&filter).await }
                 })
                 .await
         }) as Pin<Box<dyn Future<Output = (MethodName, Result<(), TestError>)> + Send>>
-    };
+    }};
 }
 
 /// Macro to create raw request and box the future result.
 #[macro_export]
 macro_rules! rpc_raw {
-    ($self:expr, $method:ident, $ret:ident $(, $args:expr )* ) => {
+    ($self:expr, $method:ident, $ret:ident $(, $args:expr )* ) => {{
+        let args_str = Some(format!("{}", [$(format!("{:?}", $args)),*].join(", ")));
         Box::pin($self.test_rpc_call(
             stringify!($method),
+            args_str,
             move |provider: &P| {
                 provider.raw_request::<_, $ret>(stringify!($method).into(), $( $args.clone(), )*)
             }
         )) as Pin<Box<dyn Future<Output = (MethodName, Result<(), TestError>)> + Send>>
-    };
+    }};
 }

--- a/crates/rpc-tester/src/tester.rs
+++ b/crates/rpc-tester/src/tester.rs
@@ -236,6 +236,7 @@ where
     async fn test_rpc_call<'a, F, Fut, T, E>(
         &'a self,
         name: &str,
+        args: Option<String>,
         method_call: F,
     ) -> (MethodName, Result<(), TestError>)
     where
@@ -266,6 +267,7 @@ where
                     Err(TestError::Diff {
                         rpc1: serde_json::to_value(&rpc1).expect("should json"),
                         rpc2: serde_json::to_value(&rpc2).expect("should json"),
+                        args,
                     })
                 }
             }


### PR DESCRIPTION
Adds more information to the errors so it's clear which endpoint failed with what args