### PR TITLE
ci: auto-build Docker image on push to main

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,7 @@ name: docker
 on:
   workflow_dispatch: {}
   push:
+    branches: [main]
     tags:
       - v*
 
@@ -28,9 +29,13 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Get short commit
+        id: vars
+        run: echo "sha_short=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
+
       - name: Build and push tagged
         uses: docker/build-push-action@v6
-        if: github.event_name != 'workflow_dispatch'
+        if: startsWith(github.ref, 'refs/tags/')
         with:
           context: .
           file: Dockerfile
@@ -39,17 +44,13 @@ jobs:
           tags: |
             ghcr.io/tempoxyz/rpc-tester:latest
             ghcr.io/tempoxyz/rpc-tester:${{ github.ref_name }}
+            ghcr.io/tempoxyz/rpc-tester:${{ steps.vars.outputs.sha_short }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
-      - name: Get short commit
-        if: github.event_name == 'workflow_dispatch'
-        id: vars
-        run: echo "sha_short=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
-
-      - name: Build and push dispatched
+      - name: Build and push commit
         uses: docker/build-push-action@v6
-        if: github.event_name == 'workflow_dispatch'
+        if: ${{ !startsWith(github.ref, 'refs/tags/') }}
         with:
           context: .
           file: Dockerfile


### PR DESCRIPTION
Previously the Docker image was only built on version tags or manual `workflow_dispatch`, which meant fixes merged to main weren't deployed until someone manually triggered a build.

This caused the get_logs pagination fix (d79378b) to never be deployed — the helm chart still points to the pre-fix image (`842be9c`).

**Changes:**
- Add `push: branches: [main]` trigger
- Consolidate build steps: tag pushes get `latest` + version + SHA tags; branch pushes and dispatches get SHA tags only

After this merges, the workflow will auto-run and produce image `ghcr.io/tempoxyz/rpc-tester:<sha>`, which can then be updated in the helm chart.