### PR TITLE
Fix blocking `std::thread::sleep` in async runtime

### DIFF
--- a/crates/rpc-tester-cli/src/main.rs
+++ b/crates/rpc-tester-cli/src/main.rs
@@ -6,7 +6,6 @@ use clap::Parser;
 use rpc_tester::RpcTester;
 use std::{
     ops::RangeInclusive,
-    thread::sleep,
     time::{Duration, Instant},
 };
 use tracing::info;
@@ -89,7 +88,6 @@ pub async fn wait_for_readiness<P: Provider<AnyNetwork>>(
     rpc2: &P,
     block_size_range: u64,
 ) -> eyre::Result<RangeInclusive<u64>> {
-    let sleep = || sleep(Duration::from_secs(5));
     let args = CliArgs::parse();
     let start_time = Instant::now();
     let timeout = Duration::from_secs(args.timeout);
@@ -103,7 +101,7 @@ pub async fn wait_for_readiness<P: Provider<AnyNetwork>>(
             ));
         }
         info!(?sync_info, "rpc1 still syncing");
-        sleep();
+        tokio::time::sleep(Duration::from_secs(5)).await;
     }
 
     // Waits until rpc1 has _mostly_ catch up to rpc2 or beyond
@@ -118,7 +116,6 @@ pub async fn wait_for_readiness<P: Provider<AnyNetwork>>(
             return Ok(range);
         }
         info!(?tip1, ?tip2, "rpc1 is behind rpc2, waiting for it to catch up");
-
-        sleep();
+        tokio::time::sleep(Duration::from_secs(5)).await;
     }
 }


### PR DESCRIPTION
### Issue:
`wait_for_readiness` is an async function but used `std::thread::sleep`, which blocks the Tokio runtime. Since this function is awaited from `main`, blocking calls pause the entire async executor for 5 seconds on each retry.

### Fix:
Replaced `std::thread::sleep` with `tokio::time::sleep(...).await` and removed the blocking import and closure.

### Impact:
The function is now fully non-blocking and correctly cooperates with the async runtime. This prevents unnecessary executor blocking and improves overall responsiveness.