### PR TITLE
ci: tag latest on every push to main

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,6 +57,7 @@ jobs:
           platforms: linux/amd64
           push: true
           tags: |
+            ghcr.io/tempoxyz/rpc-tester:latest
             ghcr.io/tempoxyz/rpc-tester:${{ steps.vars.outputs.sha_short }}
           cache-from: type=gha
           cache-to: type=gha,mode=max


### PR DESCRIPTION
Updates the Docker release workflow to also push the `latest` tag on every push to `main`, not just on version tags. This ensures helm-charts always pull the most recent build.